### PR TITLE
Revert "Dialer: truncate hint text for search box"

### DIFF
--- a/res/layout/search_edittext.xml
+++ b/res/layout/search_edittext.xml
@@ -48,8 +48,6 @@
                 android:fontFamily="@string/search_font_family"
                 android:textColorHint="@color/searchbox_hint_text_color"
                 android:gravity="center_vertical"
-                android:ellipsize="end"
-                android:maxLines="1"
                 android:hint="@string/dialer_hint_find_contact" />
 
         </LinearLayout>


### PR DESCRIPTION
This is fixed in AOSP 5.1

This reverts commit afd6610cd2f0760e17a7e42719dd85f1a8f9becc.

Change-Id: I483159a3210286da909ffa4ad715f638e6f20182